### PR TITLE
add post_id to $marker_options

### DIFF
--- a/classes/Pronamic/Google/Maps/Mashup.php
+++ b/classes/Pronamic/Google/Maps/Mashup.php
@@ -122,6 +122,7 @@ class Pronamic_Google_Maps_Mashup {
 				$marker->lng = $pgm->longitude;
 				$marker->title = $pgm->title;
 				$marker->description = $description;
+				$marker->post_id = get_the_ID();
 				
 				$options->markers[] = $marker;
 


### PR DESCRIPTION
I made a map where I needed to "bind" the markers on the map to a custom post type dropdown on the same page. 
The way it was solved was by adding `$marker->post_id = get_the_ID();` to line 125 of `mashup.php`
